### PR TITLE
클라이언트 구조 변경

### DIFF
--- a/src/main/java/com/example/ku_novel/client/ClientMain.java
+++ b/src/main/java/com/example/ku_novel/client/ClientMain.java
@@ -1,37 +1,10 @@
 package com.example.ku_novel.client;
 
-import com.example.ku_novel.client.connection.ClientListenerThread;
-import com.example.ku_novel.client.ui.LoginUI;
-
-import javax.swing.*;
-import java.io.IOException;
-import java.net.Socket;
+import com.example.ku_novel.client.ui.UIHandler;
 
 public class ClientMain {
-
     public static void main(String[] args) {
-        Socket socket = null;
-        try {
-            socket = new Socket("127.0.0.1", 10100);
-            new ClientListenerThread(socket).run();
-
-            new ClientMain().showLoginUI();
-        }catch (Exception e){
-            System.out.println(e.getMessage());
-        }finally {
-            try {
-                if (socket != null && !socket.isClosed()) socket.close();
-            } catch (IOException e) {
-                System.out.println(e.getMessage());
-            }
-        }
-    }
-
-    public void showLoginUI() {
-        SwingUtilities.invokeLater(() -> new LoginUI(this));
-    }
-
-    public void startClient(String username) {
-        // to-do: 서버 로그인 승인 응답을 받아 메인 페이지에 랜딩 처리
+        UIHandler uiHandler = new UIHandler();
+        uiHandler.showLoginUI();
     }
 }

--- a/src/main/java/com/example/ku_novel/client/connection/ClientListenerThread.java
+++ b/src/main/java/com/example/ku_novel/client/connection/ClientListenerThread.java
@@ -1,26 +1,50 @@
 package com.example.ku_novel.client.connection;
 
+import com.example.ku_novel.common.Message;
+import com.example.ku_novel.common.MessageType;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
 import java.io.*;
 import java.net.Socket;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class ClientListenerThread extends Thread {
-    private Socket socket = null;
+    private final Socket socket;
+    private final ConcurrentLinkedQueue<Message> messageQueue;
+    private final Gson gson;
 
-    public ClientListenerThread(Socket socket) {
+    public ClientListenerThread(Socket socket, ConcurrentLinkedQueue<Message> messageQueue) {
         this.socket = socket;
+        this.messageQueue = messageQueue;
+        this.gson = new Gson();
     }
 
+    @Override
     public void run() {
         BufferedReader br = null;
-
-        try{
-            String line = null;
+        try {
             br = new BufferedReader(new InputStreamReader(socket.getInputStream()));
-
-            System.out.println("Listener 스레드 실행 확인");
-
+            String line = null;
             while ((line = br.readLine()) != null) {
-                //전달받은 데이터 처리 부분
+                JsonObject jsonObject = gson.fromJson(line, JsonObject.class);
+                String messageType = jsonObject.has("messageType") ? jsonObject.get("messageType").getAsString() : "";
+
+                System.out.println(line + "응답 도착");
+                // 새 UI 컴포넌트 실행
+                if (messageType.isEmpty()) {
+                    throw new Exception();
+                }else if (messageType.equals(MessageType.LOGIN_SUCCESS.toString())) {
+                    // 로그인 성공 처리
+                    System.out.println("로그인 성공");
+                }else if (messageType.equals(MessageType.LOGIN_FAILED.toString())){
+                    // 로그인 실패 처리
+                    System.out.println("로그인 실패");
+                } else{ // 메시지 큐에 추가해서 UI 컴포넌트 내에서 처리
+                    Message message = gson.fromJson(jsonObject, Message.class);
+                    messageQueue.add(message);
+                    System.out.println(message + " 가 큐에 추가됨");
+                }
             }
         }catch (Exception e){
             System.out.println(e.getMessage());
@@ -28,7 +52,9 @@ public class ClientListenerThread extends Thread {
             try{
                 if (br != null) br.close();
                 if (socket != null) socket.close();
-            }catch (Exception e){}
+            }catch (Exception e){
+                System.out.println(e.getMessage());
+            }
         }
     }
 }

--- a/src/main/java/com/example/ku_novel/client/connection/ClientSenderThread.java
+++ b/src/main/java/com/example/ku_novel/client/connection/ClientSenderThread.java
@@ -1,0 +1,34 @@
+package com.example.ku_novel.client.connection;
+
+import com.example.ku_novel.common.Message;
+import com.example.ku_novel.common.MessageType;
+import com.google.gson.Gson;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.Socket;
+
+public class ClientSenderThread extends Thread{
+    private final Socket socket;
+    private PrintWriter writer = null;
+
+    public ClientSenderThread(Socket socket) {
+        this.socket = socket;
+    }
+
+    @Override
+    public void run() {
+        try{
+            writer = new PrintWriter(socket.getOutputStream(), true);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void requestLogin(String username, String password){
+        Message loginMessage = new Message();
+        loginMessage.setType(MessageType.LOGIN);
+
+        writer.println(loginMessage.toJson());
+    }
+}

--- a/src/main/java/com/example/ku_novel/client/ui/HomeUI.java
+++ b/src/main/java/com/example/ku_novel/client/ui/HomeUI.java
@@ -1,0 +1,7 @@
+package com.example.ku_novel.client.ui;
+
+import javax.swing.*;
+
+public class HomeUI extends JFrame {
+    public HomeUI() {}
+}

--- a/src/main/java/com/example/ku_novel/client/ui/LoginUI.java
+++ b/src/main/java/com/example/ku_novel/client/ui/LoginUI.java
@@ -1,6 +1,6 @@
 package com.example.ku_novel.client.ui;
 
-import com.example.ku_novel.client.ClientMain;
+import com.example.ku_novel.client.connection.ClientSenderThread;
 
 import javax.swing.*;
 import java.awt.*;
@@ -9,10 +9,7 @@ import java.awt.event.ActionListener;
 
 public class LoginUI extends JFrame {
 
-    private ClientMain clientMain;
-
-    public LoginUI(ClientMain clientMain) {
-        this.clientMain = clientMain;
+    public LoginUI(ClientSenderThread senderThread) {
 
         setTitle("Login");
         setSize(1080, 720);
@@ -42,10 +39,10 @@ public class LoginUI extends JFrame {
                 String username = userText.getText();
                 String password = new String(passwordText.getPassword());
 
-                System.out.println("서버에 로그인 요청 전송: " + username + " / " + password);
-
+                try {
+                    senderThread.requestLogin(username, password);
+                } catch (Exception ex) {}
                 dispose();
-                clientMain.startClient(username);
             }
         });
 

--- a/src/main/java/com/example/ku_novel/client/ui/UIHandler.java
+++ b/src/main/java/com/example/ku_novel/client/ui/UIHandler.java
@@ -1,0 +1,44 @@
+package com.example.ku_novel.client.ui;
+
+import com.example.ku_novel.client.connection.ClientListenerThread;
+import com.example.ku_novel.client.connection.ClientSenderThread;
+import com.example.ku_novel.common.Message;
+
+import javax.swing.*;
+import java.io.PrintWriter;
+import java.net.Socket;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+public class UIHandler {
+    private Socket socket;
+    private PrintWriter writer;
+    private ConcurrentLinkedQueue<Message> messageQueue = new ConcurrentLinkedQueue<>();
+    private ClientSenderThread clientSenderThread;
+
+    // 생성자에서 데몬 스레드 실행
+    public UIHandler() {
+        try {
+            socket = new Socket("127.0.0.1", 10100);
+
+            // 서버 요청 수신 스레드
+            ClientListenerThread clientListenerThread = new ClientListenerThread(socket, messageQueue);
+            clientListenerThread.start();
+
+            // 서버 요청 전송 스레드
+            clientSenderThread = new ClientSenderThread(socket);
+            clientSenderThread.start();
+        }catch (Exception e){
+            System.out.println(e.getMessage());
+        }/*finally {
+            try {
+                if (socket != null && !socket.isClosed()) socket.close();
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            }
+        }*/
+    }
+
+    public void showLoginUI() {
+        SwingUtilities.invokeLater(() -> new LoginUI(clientSenderThread));
+    }
+}

--- a/src/main/java/com/example/ku_novel/common/MessageType.java
+++ b/src/main/java/com/example/ku_novel/common/MessageType.java
@@ -1,8 +1,18 @@
 package com.example.ku_novel.common;
 
 public enum MessageType {
-    LOGIN,
-    LOGOUT,
-    REGISTER,
-    CHAT
+    LOGIN("LOGIN"),
+    LOGOUT("LOGOUT"),
+    LOGIN_SUCCESS("LOGIN_SUCCESS"),
+    LOGIN_FAILED("LOGIN_FAILED");
+
+    private String messageType;
+
+    MessageType(String messageType) {
+        this.messageType = messageType;
+    }
+
+    public String toString() {
+        return messageType;
+    }
 }


### PR DESCRIPTION
- `ClientMain`은 `UIHandler`을 호출하는 역할을 담당
- `MessageType` 수정
- `ClientListenerThread`
  - 소켓의 입력 스트림으로부터 서버 데이터 수신
  - 입력 데이터에 따른 분기 처리는 UIHandler으로 이동할 수도 있음
- `ClientSenderThread`
  - 소켓 출력 스트림으로 데이터 전송
  - 최초에 구상은 스레드를 매번 생성하고 닫는 쪽으로 생각했지만 연결을 유지하는 데몬 스레드로 일단 구현하였음
- `LoginUI`, `HomeUI`
  - 클라이언트의 노출부에 해당하며 `UIHandler`에 의해 호출되는 컴포넌트들임