### PR TITLE
REFACTOR - `ClientSenderThread`를 싱글톤으로 변경 

### DIFF
--- a/src/main/java/com/example/ku_novel/client/connection/ClientSenderThread.java
+++ b/src/main/java/com/example/ku_novel/client/connection/ClientSenderThread.java
@@ -1,5 +1,6 @@
 package com.example.ku_novel.client.connection;
 
+import com.example.ku_novel.client.ui.UIHandler;
 import com.example.ku_novel.common.Message;
 import com.example.ku_novel.common.MessageType;
 
@@ -8,11 +9,28 @@ import java.io.PrintWriter;
 import java.net.Socket;
 
 public class ClientSenderThread extends Thread{
+    private static ClientSenderThread instance;
     private final Socket socket;
     private PrintWriter writer = null;
 
-    public ClientSenderThread(Socket socket) {
+    private ClientSenderThread(Socket socket) {
         this.socket = socket;
+    }
+
+    public static synchronized ClientSenderThread initialize(Socket socket) {
+        if (instance == null) {
+            instance = new ClientSenderThread(socket);
+        } else {
+            throw new IllegalStateException("ClientSenderThread 가 이미 존재합니다.");
+        }
+        return instance;
+    }
+
+    public static synchronized ClientSenderThread getInstance() {
+        if (instance == null) {
+            throw new IllegalStateException("ClientSenderThread 가 존재하지 않습니다.");
+        }
+        return instance;
     }
 
     @Override

--- a/src/main/java/com/example/ku_novel/client/ui/LoginUI.java
+++ b/src/main/java/com/example/ku_novel/client/ui/LoginUI.java
@@ -9,7 +9,7 @@ import java.awt.event.ActionListener;
 
 public class LoginUI extends JFrame {
 
-    public LoginUI(ClientSenderThread senderThread) {
+    public LoginUI() {
 
         setTitle("로그인");
         setSize(1080, 720);
@@ -44,7 +44,7 @@ public class LoginUI extends JFrame {
                 String password = new String(passwordText.getPassword());
 
                 try {
-                    senderThread.requestLogin(username, password);
+                    ClientSenderThread.getInstance().requestLogin(username, password);
                 } catch (Exception ex) {}
                 //dispose();
             }

--- a/src/main/java/com/example/ku_novel/client/ui/SignUpModalUI.java
+++ b/src/main/java/com/example/ku_novel/client/ui/SignUpModalUI.java
@@ -10,7 +10,7 @@ public class SignUpModalUI extends JDialog {
     private JPasswordField passwordField;
     private JTextField userNameField;
 
-    public SignUpModalUI(JFrame parent, ClientSenderThread senderThread) {
+    public SignUpModalUI(JFrame parent) {
         super(parent, "회원가입", true);
         setSize(800, 600);
         setLocationRelativeTo(parent);
@@ -38,7 +38,7 @@ public class SignUpModalUI extends JDialog {
         mainPanel.add(userIdField, gbc);
 
         JButton idValidationButton = new JButton("아이디 중복 확인");
-        idValidationButton.addActionListener(e -> handleUserIdValidation(senderThread));
+        idValidationButton.addActionListener(e -> handleUserIdValidation());
         gbc.gridx = 2;
         gbc.anchor = GridBagConstraints.WEST;
         mainPanel.add(idValidationButton, gbc);
@@ -70,14 +70,14 @@ public class SignUpModalUI extends JDialog {
         mainPanel.add(userNameField, gbc);
 
         JButton userNameValidationButton = new JButton("닉네임 중복 확인");
-        userNameValidationButton.addActionListener(e -> handleUserNameValidation(senderThread));
+        userNameValidationButton.addActionListener(e -> handleUserNameValidation());
         gbc.gridx = 2;
         gbc.anchor = GridBagConstraints.WEST;
         mainPanel.add(userNameValidationButton, gbc);
 
         // 회원가입 버튼
         JButton signUpButton = new JButton("회원가입");
-        signUpButton.addActionListener(e -> handleSignUp(senderThread));
+        signUpButton.addActionListener(e -> handleSignUp());
         gbc.gridx = 1;
         gbc.gridy = 3;
         gbc.anchor = GridBagConstraints.EAST;
@@ -94,7 +94,7 @@ public class SignUpModalUI extends JDialog {
         setVisible(true);
     }
 
-    private void handleSignUp(ClientSenderThread senderThread) {
+    private void handleSignUp() {
         String userId = userIdField.getText();
         String password = new String(passwordField.getPassword());
         String userName = userNameField.getText();
@@ -106,14 +106,14 @@ public class SignUpModalUI extends JDialog {
         }
 
         try {
-            senderThread.requestSignUp(userId, password, userName);
+            ClientSenderThread.getInstance().requestSignUp(userId, password, userName);
         } catch (Exception ex) {
             JOptionPane.showMessageDialog(this, "회원가입 중 오류가 발생했습니다.", "오류", JOptionPane.ERROR_MESSAGE);
             ex.printStackTrace();
         }
     }
 
-    private void handleUserIdValidation(ClientSenderThread senderThread) {
+    private void handleUserIdValidation() {
         String userId = userIdField.getText();
 
         if (userId.isEmpty()) {
@@ -122,14 +122,14 @@ public class SignUpModalUI extends JDialog {
         }
 
         try {
-            senderThread.requestIdValidation(userId);
+            ClientSenderThread.getInstance().requestIdValidation(userId);
         } catch (Exception ex) {
             JOptionPane.showMessageDialog(this, "회원가입 중 오류가 발생했습니다.", "오류", JOptionPane.ERROR_MESSAGE);
             ex.printStackTrace();
         }
     }
 
-    private void handleUserNameValidation(ClientSenderThread senderThread) {
+    private void handleUserNameValidation() {
         String userName = userNameField.getText();
 
         if (userName.isEmpty()) {
@@ -138,7 +138,7 @@ public class SignUpModalUI extends JDialog {
         }
 
         try {
-            senderThread.requestNicknameValidation(userName);
+            ClientSenderThread.getInstance().requestNicknameValidation(userName);
         } catch (Exception ex) {
             JOptionPane.showMessageDialog(this, "회원가입 중 오류가 발생했습니다.", "오류", JOptionPane.ERROR_MESSAGE);
             ex.printStackTrace();

--- a/src/main/java/com/example/ku_novel/client/ui/UIHandler.java
+++ b/src/main/java/com/example/ku_novel/client/ui/UIHandler.java
@@ -15,7 +15,6 @@ public class UIHandler {
     private Socket socket;
     private PrintWriter writer;
     private ConcurrentLinkedQueue<Message> messageQueue = new ConcurrentLinkedQueue<>();
-    private ClientSenderThread clientSenderThread;
 
     // 생성자에서 데몬 스레드 실행
     public UIHandler() {
@@ -28,8 +27,8 @@ public class UIHandler {
             clientListenerThread.start();
 
             // 서버 요청 전송 스레드
-            clientSenderThread = new ClientSenderThread(socket);
-            clientSenderThread.start();
+            ClientSenderThread.initialize(socket);
+            ClientSenderThread.getInstance().start();
         }catch (Exception e){
             System.out.println(e.getMessage());
         }/*finally {
@@ -50,8 +49,8 @@ public class UIHandler {
 
 
     public void showLoginUI() {
-        SwingUtilities.invokeLater(() -> new LoginUI(clientSenderThread));
+        SwingUtilities.invokeLater(() -> new LoginUI());
     }
 
-    public void showSignUpModalUI(JFrame frame) { SwingUtilities.invokeLater(() -> new SignUpModalUI(frame, clientSenderThread)); }
+    public void showSignUpModalUI(JFrame frame) { SwingUtilities.invokeLater(() -> new SignUpModalUI(frame)); }
 }


### PR DESCRIPTION
- 송신 스레드를 매번 여닫지 않고 하나만 만들어 재사용하는 것으로 이야기하였음
- 이에 알맞게 싱글톤 패턴을 사용하도록 수정
- `ClientSenderThread.initialize()` 으로 스레드 생성
- `ClientSenderThread .getInstance()` 으로 인스턴스 접근