### PR TITLE
FEATURE - 로그인 실패 alert 구현 

### DIFF
--- a/src/main/java/com/example/ku_novel/client/connection/ClientListenerThread.java
+++ b/src/main/java/com/example/ku_novel/client/connection/ClientListenerThread.java
@@ -1,11 +1,13 @@
 package com.example.ku_novel.client.connection;
 
 import com.example.ku_novel.client.ui.HomeUI;
+import com.example.ku_novel.client.ui.UIHandler;
 import com.example.ku_novel.common.Message;
 import com.example.ku_novel.common.MessageType;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 
+import javax.swing.*;
 import java.io.*;
 import java.net.Socket;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -28,6 +30,7 @@ public class ClientListenerThread extends Thread {
             br = new BufferedReader(new InputStreamReader(socket.getInputStream()));
             String line = null;
             while ((line = br.readLine()) != null) {
+                UIHandler uiHandler = UIHandler.getInstance();
                 JsonObject jsonObject = gson.fromJson(line, JsonObject.class);
                 String messageType = jsonObject.has("type") ? jsonObject.get("type").getAsString() : "";
 
@@ -39,9 +42,11 @@ public class ClientListenerThread extends Thread {
                     // 로그인 성공 처리
                     System.out.println("로그인 성공");
                     HomeUI homeUI = new HomeUI();
+                    uiHandler.disposeLoginUI();
                 }else if (messageType.equals(MessageType.LOGIN_FAILED.toString())){
                     // 로그인 실패 처리
                     System.out.println("로그인 실패");
+                    uiHandler.showAlertModal(null, "경고", "아이디 비밀번호를 다시 확인해 주세요.", JOptionPane.ERROR_MESSAGE);
                 } else{ // 메시지 큐에 추가해서 UI 컴포넌트 내에서 처리
                     Message message = gson.fromJson(jsonObject, Message.class);
                     messageQueue.add(message);

--- a/src/main/java/com/example/ku_novel/client/ui/LoginUI.java
+++ b/src/main/java/com/example/ku_novel/client/ui/LoginUI.java
@@ -46,7 +46,6 @@ public class LoginUI extends JFrame {
                 try {
                     ClientSenderThread.getInstance().requestLogin(username, password);
                 } catch (Exception ex) {}
-                dispose();
             }
         });
 

--- a/src/main/java/com/example/ku_novel/client/ui/UIHandler.java
+++ b/src/main/java/com/example/ku_novel/client/ui/UIHandler.java
@@ -15,6 +15,7 @@ public class UIHandler {
     private Socket socket;
     private PrintWriter writer;
     private ConcurrentLinkedQueue<Message> messageQueue = new ConcurrentLinkedQueue<>();
+    private LoginUI loginUI;
 
     // 생성자에서 데몬 스레드 실행
     public UIHandler() {
@@ -47,10 +48,28 @@ public class UIHandler {
         return instance;
     }
 
-
     public void showLoginUI() {
-        SwingUtilities.invokeLater(() -> new LoginUI());
+        SwingUtilities.invokeLater(() -> {
+            if (loginUI == null || !loginUI.isVisible()) { // 이미 창이 열려 있지 않을 때만 새로 생성
+                loginUI = new LoginUI();
+            }
+        });
+    }
+
+    public void disposeLoginUI() {
+        SwingUtilities.invokeLater(() -> {
+            if (loginUI != null) { // 로그인 UI가 존재하면 닫기
+                loginUI.dispose();
+                loginUI = null; // 참조 해제
+            }
+        });
     }
 
     public void showSignUpModalUI(JFrame frame) { SwingUtilities.invokeLater(() -> new SignUpModalUI(frame)); }
+
+    public void showAlertModal(Component parentComponent, String title, String message, int messageType) {
+        SwingUtilities.invokeLater(() ->
+                JOptionPane.showMessageDialog(parentComponent, message, title, messageType)
+        );
+    }
 }


### PR DESCRIPTION
- 서버쪽 응답을 수신하는 ListenerThread가 uiHandler을 호출하여 ui를 업데이트
  - 응답이 `MessageType.LOGIN_SUCCESS`이면 `HomeUI` 인스턴스를 만들고 `uiHandler.disposeLoginUI`를 호출하여 로그인 창을 닫는다.
  - 응답이 `MessageType.LOGIN_FAILED`이면 `uiHandler.showAlertModal`으로 alert창을 띄운다.