### PR TITLE
소설 입력/투표 진행 모달 UI 구현

### DIFF
--- a/src/main/java/com/example/ku_novel/client/model/VoteTableModel.java
+++ b/src/main/java/com/example/ku_novel/client/model/VoteTableModel.java
@@ -1,0 +1,53 @@
+package com.example.ku_novel.client.model;
+
+import javax.swing.table.AbstractTableModel;
+
+public class VoteTableModel extends AbstractTableModel {
+    private final String[] columnNames = {"소설 내용", "선택"};
+    private final Object[][] data = {
+            {"이것은 소설 1의 내용입니다.", false},
+            {"이것은 소설 2의 내용입니다.", false},
+            {"이것은 소설 3의 내용입니다.", false}
+    };
+
+    private int selectedRow = -1; // 현재 선택된 행
+
+    @Override
+    public int getRowCount() {
+        return data.length;
+    }
+
+    @Override
+    public int getColumnCount() {
+        return columnNames.length;
+    }
+
+    @Override
+    public String getColumnName(int column) {
+        return columnNames[column];
+    }
+
+    @Override
+    public Object getValueAt(int row, int column) {
+        return data[row][column];
+    }
+
+    @Override
+    public boolean isCellEditable(int row, int column) {
+        return column == 1; // "선택" 열만 편집 가능
+    }
+
+    @Override
+    public void setValueAt(Object value, int row, int column) {
+        if (column == 1) {
+            // 이전 선택 해제
+            if (selectedRow != -1) {
+                data[selectedRow][column] = false;
+            }
+            // 새로운 선택
+            data[row][column] = true;
+            selectedRow = row;
+            fireTableDataChanged(); // 테이블 갱신
+        }
+    }
+}

--- a/src/main/java/com/example/ku_novel/client/ui/NovelInputModalUI.java
+++ b/src/main/java/com/example/ku_novel/client/ui/NovelInputModalUI.java
@@ -1,0 +1,117 @@
+package com.example.ku_novel.client.ui;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.File;
+import java.io.IOException;
+
+public class NovelInputModalUI extends JDialog {
+    private static final int TIME_LIMIT_SECONDS = 10; // 제한 시간 (초 단위)
+
+    public NovelInputModalUI(JFrame parent) {
+        super(parent, "다음 내용 입력", true);
+        setLayout(new GridBagLayout());
+        setSize(800, 600);
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(10, 20, 10, 20);
+
+        // 타이머
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        JLabel timerLabel = new JLabel("남은 시간 표시");
+        timerLabel.setFont(loadCustomFont(16f));
+
+        add(timerLabel, gbc);
+
+        // 이전 소설 내용' 라벨
+        gbc.gridx = 0;
+        gbc.gridy = 1;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        gbc.weightx = 1.0;
+
+        JLabel preLabel = new JLabel("이전 소설 내용");
+        preLabel.setFont(loadCustomFont(16f));
+        add(preLabel, gbc);
+
+        // 이전 소설 내용
+        gbc.gridx = 0;
+        gbc.gridy = 2;
+        gbc.weighty = 2.0;
+        gbc.fill = GridBagConstraints.BOTH;
+
+        JTextArea preNovelTextArea = new JTextArea(10, 20);
+        preNovelTextArea.setFont(loadCustomFont(16f));
+        preNovelTextArea.append("이전 소설 내용입니다.");
+        preNovelTextArea.setEditable(false);
+        add(new JScrollPane(preNovelTextArea), gbc);
+
+        // '내용 입력' 라벨
+        gbc.gridx = 0;
+        gbc.gridy = 3;
+        gbc.weighty = 0;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+
+        JLabel inputLabel = new JLabel("소설 내용 입력");
+        inputLabel.setFont(loadCustomFont(16f));
+        add(inputLabel, gbc);
+
+        // 내용 입력
+        gbc.gridx = 0;
+        gbc.gridy = 4;
+        gbc.weighty = 2.0;
+        gbc.fill = GridBagConstraints.BOTH;
+
+        JTextArea novelInputTextArea = new JTextArea(10, 20);
+        novelInputTextArea.setFont(loadCustomFont(16f));
+        novelInputTextArea.append("소설 입력창입니다.");
+        add(new JScrollPane(novelInputTextArea), gbc);
+
+        // 버튼 패널
+        JPanel buttonPanel = new JPanel();
+        buttonPanel.setLayout(new FlowLayout(FlowLayout.RIGHT));
+        JButton okButton = new JButton("등록");
+        okButton.setFont(loadCustomFont(16f));
+        JButton cancelButton = new JButton("취소");
+        cancelButton.setFont(loadCustomFont(16f));
+        buttonPanel.add(okButton);
+        buttonPanel.add(cancelButton);
+
+        // 확인 버튼 동작
+        okButton.addActionListener(e -> {
+            JOptionPane.showMessageDialog(this, "등록 완료");
+            dispose();
+        });
+
+        // 취소 버튼 동작
+        cancelButton.addActionListener(e -> {
+            dispose();
+        });
+
+        // 버튼 패널 추가
+        gbc.gridx = 0;
+        gbc.gridy = 5;
+        gbc.gridwidth = 2;
+        gbc.fill = GridBagConstraints.NONE;
+        gbc.weightx = 0;
+        gbc.weighty = 0;
+        gbc.anchor = GridBagConstraints.CENTER;
+        add(buttonPanel, gbc);
+
+        // JDialog 설정
+        setLocationRelativeTo(parent);
+    }
+
+    private Font loadCustomFont(float size) {
+        try {
+            return Font.createFont(Font.TRUETYPE_FONT, new File("src/main/resources/font/Pretendard-Medium.otf")).deriveFont(size);
+        } catch (FontFormatException | IOException e) {
+            e.printStackTrace();
+            System.out.println("폰트를 로드하는 데 실패했습니다.");
+            return new Font("SansSerif", Font.PLAIN, (int) size);
+        }
+    }
+}
+

--- a/src/main/java/com/example/ku_novel/client/ui/NovelRoomUI.java
+++ b/src/main/java/com/example/ku_novel/client/ui/NovelRoomUI.java
@@ -4,6 +4,8 @@ import javax.swing.*;
 import javax.swing.border.LineBorder;
 import javax.swing.text.DefaultCaret;
 import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.IOException;
 
@@ -104,12 +106,20 @@ public class NovelRoomUI extends JFrame {
         writeButton.setBorder(new LineBorder(Color.LIGHT_GRAY, 2));
         buttonPanel.add(writeButton);
 
+        writeButton.addActionListener(e-> {
+            UIHandler.getInstance().showNovelInputModal(NovelRoomUI.this);
+        });
+
         // 투표 버튼
         JButton voteButton = new JButton("(일반) 투표");
         voteButton.setPreferredSize(new Dimension(120, 40));
         voteButton.setBackground(Color.WHITE);
         voteButton.setBorder(new LineBorder(Color.LIGHT_GRAY, 2));
         buttonPanel.add(voteButton);
+
+        voteButton.addActionListener(e-> {
+            UIHandler.getInstance().showVoteModal(NovelRoomUI.this);
+        });
 
         contentPanel.add(buttonPanel);
 

--- a/src/main/java/com/example/ku_novel/client/ui/UIHandler.java
+++ b/src/main/java/com/example/ku_novel/client/ui/UIHandler.java
@@ -22,6 +22,8 @@ public class UIHandler {
     private SignUpModalUI signUpModalUI;
     private NovelRoomCreateModalUI novelRoomCreateModalUI;
     private RoomSearchResultsModalUI roomSearchResultsModalUI;
+    private NovelInputModalUI novelInputModalUI;
+    private VoteModalUI voteModalUI;
 
     // 생성자에서 데몬 스레드 실행
     public UIHandler() {
@@ -136,5 +138,23 @@ public class UIHandler {
         SwingUtilities.invokeLater(() ->
                 JOptionPane.showMessageDialog(parentComponent, message, title, messageType)
         );
+    }
+
+    public void showNovelInputModal(JFrame frame) {
+        SwingUtilities.invokeLater(() -> {
+            if(novelInputModalUI == null || !novelInputModalUI.isVisible()) {
+                novelInputModalUI = new NovelInputModalUI(frame);
+                novelInputModalUI.setVisible(true);
+            }
+        });
+    }
+
+    public void showVoteModal(JFrame frame) {
+        SwingUtilities.invokeLater(() -> {
+            if(voteModalUI == null || !voteModalUI.isVisible()) {
+                voteModalUI = new VoteModalUI(frame);
+                voteModalUI.setVisible(true);
+            }
+        });
     }
 }

--- a/src/main/java/com/example/ku_novel/client/ui/VoteModalUI.java
+++ b/src/main/java/com/example/ku_novel/client/ui/VoteModalUI.java
@@ -1,0 +1,161 @@
+package com.example.ku_novel.client.ui;
+
+import com.example.ku_novel.client.model.VoteTableModel;
+import com.example.ku_novel.domain.NovelRoom;
+
+import javax.persistence.Column;
+import javax.swing.*;
+import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableCellEditor;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableColumn;
+import java.awt.*;
+import java.io.File;
+import java.io.IOException;
+
+public class VoteModalUI extends JDialog {
+    private static final int TIME_LIMIT_SECONDS = 10; // 제한 시간 (초 단위)
+
+    public VoteModalUI(JFrame parent) {
+        super(parent, "다음 내용 선택 투표", true);
+        setLayout(new GridBagLayout());
+        setSize(800, 600);
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(20, 20, 10, 20);
+
+        // 제목 라벨
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+
+        JLabel preLabel = new JLabel("다음 소설 내용 투표");
+        preLabel.setFont(loadCustomFont(16f));
+        add(preLabel, gbc);
+
+        // 타이머
+        gbc.insets = new Insets(10, 20, 10, 20);
+
+        gbc.gridx = 1;
+        gbc.gridy = 0;
+        gbc.anchor = GridBagConstraints.EAST;
+        JLabel timerLabel = new JLabel("남은 시간 표시");
+        timerLabel.setFont(loadCustomFont(16f));
+        add(timerLabel, gbc);
+
+        // 이전 소설 내용
+        gbc.gridx = 0;
+        gbc.gridy = 2;
+        gbc.weightx = 1.0;
+        gbc.weighty = 2.0;
+        gbc.gridwidth = 2;
+        gbc.fill = GridBagConstraints.BOTH;
+
+        VoteTableModel model = new VoteTableModel();
+
+        // JTable 생성
+        JTable table = new JTable(model);
+        table.setFont(loadCustomFont(16f)); // 폰트 설정
+        table.setRowHeight(50);// 각 행의 높이 설정
+
+        // 체크박스 렌더러 및 에디터 설정
+        table.getColumn("선택").setCellRenderer(new RadioButtonRenderer());
+        table.getColumn("선택").setCellEditor(new RadioButtonEditor(model));
+
+        TableColumn column = table.getColumnModel().getColumn(1);
+        column.setPreferredWidth(120); // 원하는 너비 설정
+        column.setMinWidth(120);       // 최소 너비 설정
+        column.setMaxWidth(120);       // 최대 너비 설정
+
+        add(new JScrollPane(table), gbc);
+
+        // 버튼 패널
+        JPanel buttonPanel = new JPanel();
+        buttonPanel.setLayout(new FlowLayout(FlowLayout.RIGHT));
+        JButton okButton = new JButton("투표");
+        okButton.setFont(loadCustomFont(16f));
+        JButton cancelButton = new JButton("취소");
+        cancelButton.setFont(loadCustomFont(16f));
+        buttonPanel.add(okButton);
+        buttonPanel.add(cancelButton);
+
+        // 확인 버튼 동작
+        okButton.addActionListener(e -> {
+            JOptionPane.showMessageDialog(this, "등록 완료");
+            dispose();
+        });
+
+        // 취소 버튼 동작
+        cancelButton.addActionListener(e -> {
+            dispose();
+        });
+
+        // 버튼 패널 추가
+        gbc.insets = new Insets(10, 20, 20, 20);
+
+        gbc.gridx = 0;
+        gbc.gridy = 5;
+        gbc.gridwidth = 2;
+        gbc.fill = GridBagConstraints.NONE;
+        gbc.weightx = 0;
+        gbc.weighty = 0;
+        gbc.anchor = GridBagConstraints.CENTER;
+        add(buttonPanel, gbc);
+
+        // JDialog 설정
+        setLocationRelativeTo(parent);
+    }
+
+    private Font loadCustomFont(float size) {
+        try {
+            return Font.createFont(Font.TRUETYPE_FONT, new File("src/main/resources/font/Pretendard-Medium.otf")).deriveFont(size);
+        } catch (FontFormatException | IOException e) {
+            e.printStackTrace();
+            System.out.println("폰트를 로드하는 데 실패했습니다.");
+            return new Font("SansSerif", Font.PLAIN, (int) size);
+        }
+    }
+
+    // 체크박스 렌더러
+    static class RadioButtonRenderer extends JRadioButton implements TableCellRenderer {
+        public RadioButtonRenderer() {
+            setHorizontalAlignment(SwingConstants.CENTER);
+        }
+
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+            setSelected((Boolean) value);
+            return this;
+        }
+    }
+
+    // 체크박스 에디터
+    static class RadioButtonEditor extends AbstractCellEditor implements TableCellEditor {
+        private final JRadioButton radioButton;
+        private final VoteTableModel model;
+        private int row;
+
+        public RadioButtonEditor(VoteTableModel model) {
+            this.model = model;
+            radioButton = new JRadioButton();
+            radioButton.setHorizontalAlignment(SwingConstants.CENTER);
+
+            // 선택 시 데이터 업데이트
+            radioButton.addActionListener(e -> {
+                model.setValueAt(true, row, 1);
+                fireEditingStopped();
+            });
+        }
+
+        @Override
+        public Component getTableCellEditorComponent(JTable table, Object value, boolean isSelected, int row, int column) {
+            this.row = row;
+            radioButton.setSelected((Boolean) value);
+            return radioButton;
+        }
+
+        @Override
+        public Object getCellEditorValue() {
+            return radioButton.isSelected();
+        }
+    }
+}
+


### PR DESCRIPTION
`NovelInputModalUI`- 소설 입력 모달 UI
- 소설방 페이지에서 '(소설가) 소설 작성' 버튼을 누르면 사진과 같은 Modal이 뜸
- 이전 소설 내용: 바로 직전의 내용 표시
- 소설 내용 입력: 이어질 내용을 입력

![image](https://github.com/user-attachments/assets/e1387fdb-85c1-4734-a208-45df5126301e)

`VoteModalUI`- 투표 모달 UI
- `VoteTableModel`: 다음 소설 내용 후보 테이블 모델 
- 라디오버튼을 사용해서 다음 소설 내용 후보 중 하나를 선택하도록 구현

![image](https://github.com/user-attachments/assets/a3c2d93c-d1b5-46f5-b83b-ef53b4602262)