### PR TITLE
FIX - 활성화된 소설방을 눌러도 반응이 없는 문제

### DIFF
--- a/src/main/java/com/example/ku_novel/client/ui/HomeUI.java
+++ b/src/main/java/com/example/ku_novel/client/ui/HomeUI.java
@@ -297,9 +297,9 @@ public class HomeUI extends JFrame {
                     }
                     lastRequestTime = currentTime;
 
-                    int row = novelListTable.rowAtPoint(evt.getPoint());
+                    int row = activeNovelListTable.rowAtPoint(evt.getPoint());
                     if (row >= 0) {
-                        String roomTitle = (String) novelListTable.getValueAt(row, 0);
+                        String roomTitle = (String) activeNovelListTable.getValueAt(row, 0);
                         int roomId = activeNovelRooms.get(row).getId();
                         handleNovelRoomClick(roomId, roomTitle);
                     }


### PR DESCRIPTION
- 참여중인 소설방 테이블에 바인딩된 이벤트에서 활성화된 소설방 테이블의 데이터를 참조하고 있음
- 이벤트 발생 위치가 항상 테이블 밖에서 일어나, row값이 -1로 반환됨
- 올바른 값을 참조하도록 수정