### PR TITLE
FIX - 소설방을 생성하지 못해도 소설방 생성이 성공했다고 응답하는 문제 

### DIFF
--- a/src/main/java/com/example/ku_novel/client/connection/ClientListenerThread.java
+++ b/src/main/java/com/example/ku_novel/client/connection/ClientListenerThread.java
@@ -52,9 +52,9 @@ public class ClientListenerThread extends Thread {
     private void handleMessageType(String messageType, JsonObject jsonObject, UIHandler uiHandler) {
         switch (messageType) {
             case "LOGIN_SUCCESS" -> handleLoginSuccess(jsonObject, uiHandler);
-            case "LOGIN_FAILED", "SIGNUP_FAILED" , "ROOM_JOIN_FAILED", "REFRESH_HOME_FAILED"-> uiHandler.showAlertModal(
+            case "LOGIN_FAILED", "SIGNUP_FAILED" , "ROOM_JOIN_FAILED", "REFRESH_HOME_FAILED", "ROOM_CREATE_FAILED" -> uiHandler.showAlertModal(
                     null, "경고", jsonObject.get("content").getAsString(), JOptionPane.ERROR_MESSAGE);
-            case "ID_INVALID", "ID_VALID", "NICKNAME_INVALID", "NICKNAME_VALID" -> uiHandler.showAlertModal(
+            case "ID_INVALID", "ID_VALID", "NICKNAME_INVALID", "NICKNAME_VALID", "ROOM_CREATE_SUCCESS"-> uiHandler.showAlertModal(
                     null, "정보", jsonObject.get("content").getAsString(), JOptionPane.INFORMATION_MESSAGE);
             case "SIGNUP_SUCCESS" -> handleSignupSuccess(jsonObject, uiHandler);
             case "REFRESH_HOME_SUCCESS" -> handleRefreshHomeSuccess(jsonObject, uiHandler);

--- a/src/main/java/com/example/ku_novel/client/ui/NovelRoomCreateModalUI.java
+++ b/src/main/java/com/example/ku_novel/client/ui/NovelRoomCreateModalUI.java
@@ -126,7 +126,6 @@ public class NovelRoomCreateModalUI extends JDialog {
         try {
             // 서버에 소설방 생성 요청
             ClientSenderThread.getInstance().requestCreateNovelRoom(roomTitle, roomDescription, submissionDuration, voingDuration, novelistCount);
-            JOptionPane.showMessageDialog(this, "소설방이 생성되었습니다.", "성공", JOptionPane.INFORMATION_MESSAGE);
             dispose();
         } catch (Exception ex) {
             JOptionPane.showMessageDialog(this, "소설방 생성 중 오류가 발생했습니다.", "오류", JOptionPane.ERROR_MESSAGE);


### PR DESCRIPTION
- sender까지 구현해놓고 listener 작업을 서버 응답 구현 이후에 진행하기로 했다가 누락된 부분
- 요청 시점에 다이얼로그를 띄우는게 아닌, 응답 이후에 응답 메시지에 따라 다이얼로그를 띄우자