### PR TITLE
FEATURE - 소설 방 생성 이후에는 새로고침 요청을 보내자

### DIFF
--- a/src/main/java/com/example/ku_novel/client/connection/ClientListenerThread.java
+++ b/src/main/java/com/example/ku_novel/client/connection/ClientListenerThread.java
@@ -54,15 +54,22 @@ public class ClientListenerThread extends Thread {
             case "LOGIN_SUCCESS" -> handleLoginSuccess(jsonObject, uiHandler);
             case "LOGIN_FAILED", "SIGNUP_FAILED" , "ROOM_JOIN_FAILED", "REFRESH_HOME_FAILED", "ROOM_CREATE_FAILED" -> uiHandler.showAlertModal(
                     null, "경고", jsonObject.get("content").getAsString(), JOptionPane.ERROR_MESSAGE);
-            case "ID_INVALID", "ID_VALID", "NICKNAME_INVALID", "NICKNAME_VALID", "ROOM_CREATE_SUCCESS"-> uiHandler.showAlertModal(
+            case "ID_INVALID", "ID_VALID", "NICKNAME_INVALID", "NICKNAME_VALID"-> uiHandler.showAlertModal(
                     null, "정보", jsonObject.get("content").getAsString(), JOptionPane.INFORMATION_MESSAGE);
             case "SIGNUP_SUCCESS" -> handleSignupSuccess(jsonObject, uiHandler);
             case "REFRESH_HOME_SUCCESS" -> handleRefreshHomeSuccess(jsonObject, uiHandler);
             case "ROOM_FETCH_BY_TITLE_SUCCESS" -> handleRoomFetchByTitleSuccess(jsonObject, uiHandler);
             case "ROOM_FETCH_BY_TITLE_FAILED" -> handleRoomFetchByTitleFailed(jsonObject, uiHandler);
             case "ROOM_JOIN_SUCCESS" -> handleRoomJoinSuccess(jsonObject, uiHandler);
+            case "ROOM_CREATE_SUCCESS" -> handleRoomCreateSuccess(jsonObject, uiHandler);
             default -> enqueueMessage(jsonObject);
         }
+    }
+
+    private void handleRoomCreateSuccess(JsonObject jsonObject, UIHandler uiHandler) {
+        uiHandler.showAlertModal(
+                null, "정보", jsonObject.get("content").getAsString(), JOptionPane.INFORMATION_MESSAGE);
+        ClientSenderThread.getInstance().requestRefreshHome(ClientDataModel.getInstance().getUserId());
     }
 
     private void handleRefreshHomeSuccess(JsonObject jsonObject, UIHandler uiHandler) {


### PR DESCRIPTION
- 사용자가 소설방을 생성하면 사용자 경험적으로는 생성한 소설방이 목록에 보이는 것을 기대함
- 새로고침을 직접 누르지 않더라도, listener에서 새로고침 요청을 보내도록 하자