### PR TITLE
FIX - 소설 작성이 안되는 문제

### DIFF
--- a/src/main/java/com/example/ku_novel/server/ClientHandler.java
+++ b/src/main/java/com/example/ku_novel/server/ClientHandler.java
@@ -674,10 +674,7 @@ class ClientHandler implements Runnable {
         String sender = message.getSender();
 
         try {
-            int voteId = message.getNovelVoteId();
-            NovelRoom room = novelRoomService.getNovelRoomByCurrentVoteId(voteId);
-
-            int roomId = room.getId();
+            int roomId = message.getNovelRoomId();
             String content = message.getContent();
 
             // 소설방 정보 확인
@@ -692,6 +689,7 @@ class ClientHandler implements Runnable {
             }
 
             NovelRoom novelRoom = novelRoomOpt.get();
+            int voteId = novelRoom.getCurrentVoteId();
 
             // 소설가 권한 확인 (클라에서 막아놨지만 추가했음)
             String participantIdsJson = novelRoom.getParticipantIds();


### PR DESCRIPTION
- 클라에서는 소설 작성할때 투표 관련 데이터를 요청에 포함하지 않았는데 서버에서는 투표 아이디를 가지고 소설방을 SELECT하도록 구현되어 있음
- 클라에서 소설방 id를 요청에 포함하니 소설방 아이디로 검색하자